### PR TITLE
Use a stable version of `stdsimd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 build = "build.rs"
 
 [dependencies]
-stdsimd = { git = "https://github.com/rust-lang-nursery/stdsimd" }
+stdsimd = "0.0.3"
 
 [dev-dependencies]
 rand = "0.3"


### PR DESCRIPTION
This commit updates the `stdsimd` dependency to the version 0.0.3 (it used the Git repo until now because the required intrinsics were not yet released in the stable version).

Since the crate does not require any non-versioned dependencies now, a new version could be published to crates.io.