### PR TITLE
Use stable SIMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: rust
 rust:
+  # Test on the minimum supported version
+  - 1.27.0
+  # Test on the other Rust channels
+  - stable
   - nightly
+matrix:
+  allow_failures:
+    # Nightly might break some builds
+    - rust: nightly
+  fast_finish: true
+# Cache dependencies to speed up build
+cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 //! Otherwise, the crate will use `cpuid` at runtime to detect the
 //! running CPU's features, and enable the appropiate algorithm.
 
-#![feature(stdsimd)]
-
 mod hw;
 mod sw;
 mod util;


### PR DESCRIPTION
Rust 1.27 [has been released](https://blog.rust-lang.org/2018/06/21/Rust-1.27.html), and it bring SIMD instructions to stable.

This pull request removes the unnecessary `#![feature(stdsimd)]`. Also updates `.travis.yml` to test on stable.