### PR TITLE
Release 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: rust
+arch:
+  - amd64
+  - arm64
 rust:
   # Test on the minimum supported version
-  - 1.33.0
+  - 1.41.0
   # Test on the other Rust channels
   - stable
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crc32c"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Zack Owens"]
 license = "Apache-2.0/MIT"
 keywords = ["crc", "simd"]
@@ -17,7 +17,7 @@ exclude = [
 build = "build.rs"
 
 [dev-dependencies]
-rand = "0.4"
+rand = { version ="0.7", features=["alloc", "getrandom"] }
 criterion = "0.3"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crc32c = "0.4"
+crc32c = "0.5"
 ```
 
 ```rust

--- a/benches/rand.rs
+++ b/benches/rand.rs
@@ -4,14 +4,12 @@ extern crate rand;
 extern crate crc32c;
 
 use criterion::{Criterion, Benchmark, Throughput};
-use rand::{OsRng, Rng};
+use rand::{rngs::OsRng, RngCore};
 use crc32c::crc32c;
 
 fn crc32c_megabyte(c: &mut Criterion) {
     let mut bytes = [0u8; 1_000_000];
-
-    let mut r = OsRng::new().unwrap();
-    r.fill_bytes(&mut bytes);
+    OsRng.fill_bytes(&mut bytes);
 
     c.bench(
         "crc32_update_megabytes",


### PR DESCRIPTION
- Minimum Rust version is now 1.41
- Build/verify on ARM (not optimized for NEON instructions yet)
- Updating rand package

Closes #11 