### PR TITLE
adding crc32c combine function

### DIFF
--- a/benches/rand.rs
+++ b/benches/rand.rs
@@ -3,20 +3,94 @@ extern crate criterion;
 extern crate crc32c;
 extern crate rand;
 
-use crc32c::crc32c;
-use criterion::{Benchmark, Criterion, Throughput};
+use crc32c::{crc32c, crc32c_append, crc32c_combine};
+use criterion::{Criterion, Throughput};
 use rand::{rngs::OsRng, RngCore};
 
 fn crc32c_megabyte(c: &mut Criterion) {
     let mut bytes = [0u8; 1_000_000];
     OsRng.fill_bytes(&mut bytes);
 
-    c.bench(
-        "crc32_update_megabytes",
-        Benchmark::new("crc32_update_megabytes", move |b| b.iter(|| crc32c(&bytes)))
-            .throughput(Throughput::Bytes(1_000_000)),
-    );
+    let mut group = c.benchmark_group("crc32_update_megabytes");
+    group.throughput(Throughput::Bytes(1_000_000));
+    group.bench_function("crc32_update_megabytes", move |b| b.iter(|| crc32c(&bytes)));
+    group.finish();
 }
 
-criterion_group!(crc, crc32c_megabyte);
+fn crc32c_8kb(c: &mut Criterion) {
+    let mut buffer = [0u8; 8192];
+    OsRng.fill_bytes(&mut buffer);
+
+    let mut group = c.benchmark_group("crc32c_8kb");
+    group.throughput(Throughput::Bytes(8192));
+    group.bench_function("crc32c_8kb", move |b| b.iter(|| crc32c(&buffer)));
+    group.finish();
+}
+
+/// benchmark combining 4KB blocks into existing check values.
+fn crc32c_combine_4kb(c: &mut Criterion) {
+    let mut buffer = [0u8; 4096];
+    OsRng.fill_bytes(&mut buffer);
+
+    let crc_a = crc32c(b"abcd");
+    let crc_b = crc32c(&buffer);
+
+    let mut group = c.benchmark_group("crc32c_combine_4kb");
+    group.bench_function("crc32c_combine_4kb", move |b| {
+        b.iter(|| crc32c_combine(crc_a, crc_b, 4096))
+    });
+    group.finish();
+}
+
+/// benchmark appending 4KB blocks to existing check values
+fn crc32c_append_4kb(c: &mut Criterion) {
+    let mut buffer = [0u8; 4096];
+    OsRng.fill_bytes(&mut buffer);
+
+    let crc_a = crc32c(b"abcd");
+
+    let mut group = c.benchmark_group("crc32c_append_4kb");
+    group.bench_function("crc32c_append_4kb", move |b| {
+        b.iter(|| crc32c_append(crc_a, &buffer))
+    });
+    group.finish();
+}
+
+/// benchmark combining 1MB blocks into existing check values.
+fn crc32c_combine_megabyte(c: &mut Criterion) {
+    let mut buffer = [0u8; 1_000_000];
+    OsRng.fill_bytes(&mut buffer);
+
+    let crc_a = crc32c(b"abcd");
+    let crc_b = crc32c(&buffer);
+
+    let mut group = c.benchmark_group("crc32c_combine_megabyte");
+    group.bench_function("crc32c_combine_megabyte", move |b| {
+        b.iter(|| crc32c_combine(crc_a, crc_b, 1_000_000))
+    });
+    group.finish();
+}
+
+fn crc32c_append_megabyte(c: &mut Criterion) {
+    let mut buffer = [0u8; 1_000_000];
+    OsRng.fill_bytes(&mut buffer);
+
+    let crc_a = crc32c(b"abcd");
+
+    let mut group = c.benchmark_group("crc32c_append_megabyte");
+    group.bench_function("crc32c_append_megabyte", move |b| {
+        b.iter(|| crc32c_append(crc_a, &buffer))
+    });
+    group.finish();
+}
+
+criterion_group!(
+    crc,
+    crc32c_megabyte,
+    crc32c_8kb,
+    crc32c_append_4kb,
+    crc32c_combine_4kb,
+    crc32c_combine_megabyte,
+    crc32c_append_megabyte
+);
 criterion_main!(crc);

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -1,0 +1,105 @@
+//! Implements the CRC32c "combine" function, which calculates the CRC32c of two byte streams
+//! concatenated together using their individual CRC32c values (plus the length of the second byte
+//! stream).
+//!
+//! This module is essentially a line-by-line translation of ZLIB's CRC "combine" function
+//! implementation from C to Rust, except for the CRC polynomial used (original uses the CRC32
+//! polynomial 0xedb88320UL, we use the CRC32c polynomial 0x82F63B78).
+//!
+//! Link to original implementation: https://github.com/madler/zlib/blob/master/crc32.c
+//!
+//! This file is based on the Zlib project, located at: https://github.com/madler/zlib,
+//! which includes the following notice:
+//!
+//! crc32.c -- compute the CRC-32 of a data stream
+//! Copyright (C) 1995-2006, 2010, 2011, 2012, 2016 Mark Adler
+//! For conditions of distribution and use, see copyright notice in zlib.h
+//!
+//! Thanks to Rodney Brown <rbrown64@csc.com.au> for his contribution of faster
+//! CRC methods: exclusive-oring 32 bits of data at a time, and pre-computing
+//! tables for updating the shift register in one step with three exclusive-ors
+//! instead of four steps with four exclusive-ors.  This results in about a
+//! factor of two increase in speed on a Power PC G4 (PPC7455) using gcc -O3.
+
+const GF2_DIM: usize = 32;
+
+fn gf2_matrix_times(mat: &[u32; GF2_DIM], mut vec: u32) -> u32 {
+    let mut sum = 0;
+    let mut idx = 0;
+    while vec > 0 {
+        if vec & 1 == 1 {
+            sum ^= mat[idx];
+        }
+        vec >>= 1;
+        idx += 1;
+    }
+    return sum;
+}
+
+fn gf2_matrix_square(square: &mut [u32; GF2_DIM], mat: &[u32; GF2_DIM]) {
+    for n in 0..GF2_DIM {
+        square[n] = gf2_matrix_times(mat, mat[n]);
+    }
+}
+
+pub(crate) fn crc32c_combine(mut crc1: u32, crc2: u32, mut len2: usize) -> u32 {
+    let mut row: u32;
+    let mut even = [0u32; GF2_DIM]; /* even-power-of-two zeros operator */
+    let mut odd = [0u32; GF2_DIM]; /* odd-power-of-two zeros operator */
+
+    /* degenerate case (also disallow negative lengths) */
+    if len2 <= 0 {
+        return crc1;
+    }
+
+    /* put operator for one zero bit in odd */
+    odd[0] = 0x82F63B78; /* CRC-32c polynomial */
+    row = 1;
+    for n in 1..GF2_DIM {
+        odd[n] = row;
+        row <<= 1;
+    }
+
+    /* put operator for two zero bits in even */
+    gf2_matrix_square(&mut even, &odd);
+
+    /* put operator for four zero bits in odd */
+    gf2_matrix_square(&mut odd, &even);
+
+    /* degenerate case (also disallow negative lengths) */
+    if len2 <= 0 {
+        return crc1;
+    }
+
+    /* apply len2 zeros to crc1 (first square will put the operator for one
+    zero byte, eight zero bits, in even) */
+    loop {
+        /* apply zeros operator for this bit of len2 */
+        gf2_matrix_square(&mut even, &odd);
+        if len2 & 1 == 1 {
+            crc1 = gf2_matrix_times(&even, crc1);
+        }
+        len2 >>= 1;
+
+        /* if no more bits set, then done */
+        if len2 == 0 {
+            break;
+        }
+
+        /* another iteration of the loop with odd and even swapped */
+        gf2_matrix_square(&mut odd, &even);
+        if len2 & 1 == 1 {
+            crc1 = gf2_matrix_times(&odd, crc1);
+        }
+        len2 >>= 1;
+
+        /* if no more bits set, then done */
+        if len2 == 0 {
+            break;
+        }
+    }
+
+    /* return combined crc */
+    crc1 ^= crc2;
+    return crc1;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 #![cfg_attr(nightly, feature(stdsimd, asm, aarch64_target_feature))]
 
+mod combine;
 #[cfg(all(target_arch = "aarch64", nightly))]
 mod hw_aarch64;
 #[cfg(any(target_arch = "x86_64", all(target_arch = "aarch64", nightly)))]
@@ -57,4 +58,12 @@ pub fn crc32c_append(crc: u32, data: &[u8]) -> u32 {
     }
 
     sw::crc32c(crc, data)
+}
+
+/// Computes the "combined" value of two CRC32c values. Specifically, given two byte streams A and
+/// B and their CRC32c check values crc32c(A) and crc32c(B), this function calculates crc32c(AB)
+/// using only crc32c(A), crc32c(B), and the length of B.
+#[inline]
+pub fn crc32c_combine(crc1: u32, crc2: u32, len2: usize) -> u32 {
+    combine::crc32c_combine(crc1, crc2, len2)
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,5 +1,32 @@
 extern crate crc32c;
-use crc32c::{crc32c, crc32c_append};
+extern crate rand;
+
+use crc32c::{crc32c, crc32c_append, crc32c_combine};
+use rand::{rngs::OsRng, RngCore};
+
+#[test]
+fn crc_combine() {
+    for a_length in 0..12 {
+        for b_length in 0..12 {
+            let mut a_buf = vec![0u8; a_length];
+            let mut b_buf = vec![0u8; b_length];
+            OsRng.fill_bytes(&mut a_buf);
+            OsRng.fill_bytes(&mut b_buf);
+
+            let a = crc32c(&a_buf);
+            let b = crc32c(&b_buf);
+            let appended = crc32c_append(a, &b_buf);
+
+            let _ = &a_buf.append(&mut b_buf);
+
+            let ab = crc32c(&a_buf);
+            let combined = crc32c_combine(a, b, b_length);
+
+            assert_eq!(ab, appended);
+            assert_eq!(ab, combined);
+        }
+    }
+}
 
 #[test]
 fn crc() {


### PR DESCRIPTION
Hello Zack!

My team at AWS is a user of this crate, we wanted to get a CRC "combine" function to go along with the rest of the CRC32c goodies you have here. I went and implemented one based on an implementation from ZLIB [0], would appreciate any feedback you might have.

This is likely not the final version we want for production usage, benchmark results show that it beats `crc_append` in performance for data chunks larger than a few hundred KBs, but we would like to try out a few ideas for optimization (we're exploring hardware acceleration, in particular), to see if we can make it performant for smaller chunks of data.

Let me know what you think, cheers.

[0] Link to original implementation: https://github.com/madler/zlib/blob/master/crc32.c

-Pete