### PR TITLE
fix incorrect results on big endian targets

### DIFF
--- a/src/sw.rs
+++ b/src/sw.rs
@@ -1,6 +1,6 @@
 //! Implements crc32c without hardware support.
 
-use crate::util;
+use crate::util::{self, U64Le};
 
 /// 8-KiB lookup table.
 pub struct CrcTable([[u32; 256]; 8]);
@@ -41,9 +41,9 @@ fn crc_u8(crc: u64, buffer: &[u8]) -> u64 {
 }
 
 #[inline]
-fn crc_u64(crci: u64, buffer: &[u64]) -> u64 {
+fn crc_u64(crci: u64, buffer: &[U64Le]) -> u64 {
     buffer.iter().fold(crci, |crc, &next| {
-        let crc = crc ^ next;
+        let crc = crc ^ next.get();
 
         // Note: I've tried refactoring this to a for-loop,
         // but then it gets worse performance.

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use std::{cmp, mem, slice};
 pub(crate) struct U64Le(u64);
 
 impl U64Le {
-    #[inline]
+    #[inline(always)]
     pub const fn get(self) -> u64 {
         u64::from_le(self.0)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,14 @@
 use std::{cmp, slice};
 
+/// A newtype wrapper for a little endian `u64`.
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub(crate) struct U64Le(u64);
 
 impl U64Le {
+    /// Returns a `u64` with correct endianness for the target.
+    ///
+    /// On little endian targets, this is a no-op.
     #[allow(clippy::inline_always)]
     #[inline(always)]
     pub const fn get(self) -> u64 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,8 @@
 use std::{cmp, slice};
 
 /// A newtype wrapper for a little endian `u64`.
+///
+/// It is safe to transmute between a `u64` and `U64Le`.
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub(crate) struct U64Le(u64);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,11 @@
-use std::{cmp, mem, slice};
+use std::{cmp, slice};
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub(crate) struct U64Le(u64);
 
 impl U64Le {
+    #[allow(clippy::inline_always)]
     #[inline(always)]
     pub const fn get(self) -> u64 {
         u64::from_le(self.0)
@@ -41,7 +42,8 @@ pub(crate) fn split(buffer: &[u8]) -> (&[u8], &[U64Le], &[u8]) {
     };
 
     let mid = unsafe {
-        let ptr = mem::transmute(mid.as_ptr());
+        #[allow(clippy::cast_ptr_alignment)]
+        let ptr = mid.as_ptr().cast::<U64Le>();
         let length = mid.len() / 8;
 
         slice::from_raw_parts(ptr, length)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,21 @@
 use std::{cmp, mem, slice};
 
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub(crate) struct U64Le(u64);
+
+impl U64Le {
+    #[inline]
+    pub const fn get(self) -> u64 {
+        u64::from_le(self.0)
+    }
+}
+
 /// Splits a buffer into three subslices:
 /// - the first one is up to the first 8-byte aligned address.
 /// - the second one is 8-byte aligned and its length is a multiple of 8.
 /// - the third one is 8-byte aligned but its length is less than 8.
-pub fn split(buffer: &[u8]) -> (&[u8], &[u64], &[u8]) {
+pub(crate) fn split(buffer: &[u8]) -> (&[u8], &[U64Le], &[u8]) {
     let (start, mid) = {
         let split_index = {
             let addr = buffer.as_ptr() as usize;


### PR DESCRIPTION
fixes #34.

https://github.com/zowens/crc32c/blob/47c2999907a770daec5444cf9fcb522926d8cfe4/src/util.rs#L33

this line in `util::split` transmutes a `&[u8]` to a `&[u64]` without considering endianness, causing incorrect results on BE targets.
to fix this, i have it return a slice of the newtype `U64Le`, whose elements can be converted to `u64` correctly, accounting for platforms.
on little endian targets this is a no-op, and the conversion method `U64Le::get` is always inlined, so there shouldn't be any performance hit on those targets.

## TODO

- [X] ~benchmark on LE and BE. i expect to see no change.~
- [X] ~add more comments so its clear why this struct exists without digging through commit logs~
