### PR TITLE
Remove use of `stdsimd` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 //! Otherwise, the crate will use `cpuid` at runtime to detect the
 //! running CPU's features, and enable the appropiate algorithm.
 
-#![cfg_attr(nightly, feature(stdsimd))]
-
 mod combine;
 mod hasher;
 #[cfg(all(target_arch = "aarch64", nightly))]


### PR DESCRIPTION
From what I can see, this crate does not use anything from `stdsimd`, so it can be removed with no change in functionality.
Fixes #51.