### PR TITLE
Replace i32 with u32 in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@
 extern crate rustc_version;
 
 use rustc_version::{version_meta, Channel};
+use std::io::Write;
 use std::path::Path;
 use std::{io, ops};
 
@@ -12,7 +13,7 @@ pub const POLYNOMIAL: u32 = 0x82_F6_3B_78;
 fn sw_table() -> [[u32; 256]; 8] {
     let mut table: [[u32; 256]; 8] = [[0u32; 256]; 8];
 
-    for n in 0..256 {
+    for n in 0..256_u32 {
         let mut crc = n;
 
         for _ in 0..8 {
@@ -45,8 +46,8 @@ pub struct Matrix([u32; 32]);
 
 impl Matrix {
     /// Allocates space for a new matrix.
-    fn new() -> Self {
-        Matrix([0u32; 32])
+    const fn new() -> Self {
+        Self([0u32; 32])
     }
 
     /// Multiplies a matrix by itself.
@@ -136,10 +137,10 @@ fn hw_table(len: usize) -> [[u32; 256]; 4] {
     let mut zeroes: [[u32; 256]; 4] = [[0u32; 256]; 4];
     let op = create_zero_operator(len);
 
-    for n in 0..256 {
-        for i in 0..4 {
+    for n in 0..256_u32 {
+        for i in 0..4_u32 {
             let shift = i * 8;
-            zeroes[i as usize][n] = op * ((n << shift) as u32);
+            zeroes[i as usize][n as usize] = op * (n << shift);
         }
     }
 
@@ -151,20 +152,17 @@ pub const LONG: usize = 8192;
 pub const SHORT: usize = 256;
 
 fn write_table(table: &[[u32; 256]], path: &Path) -> io::Result<()> {
-    use std::fs;
-
     let mut file = {
-        let file = fs::File::create(path)?;
+        let file = std::fs::File::create(path)?;
         io::BufWriter::new(file)
     };
 
-    use std::io::Write;
     write!(file, "[")?;
 
-    for row in table.iter() {
+    for row in table {
         write!(file, "[")?;
-        for element in row.iter() {
-            write!(file, "{}, ", element)?;
+        for element in row {
+            write!(file, "{element}, ")?;
         }
         write!(file, "],")?;
     }
@@ -187,7 +185,7 @@ fn write_tables() -> io::Result<()> {
 fn main() {
     write_tables().expect("Failed to write CRC tables");
 
-    if let Channel::Nightly = version_meta().unwrap().channel {
+    if version_meta().unwrap().channel == Channel::Nightly {
         println!("cargo:rustc-cfg=nightly");
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn can_read() {
-        let mut reader = Crc32cReader::new(&TEST_STRING[..]);
+        let mut reader = Crc32cReader::new(TEST_STRING);
         let mut buf = Vec::default();
         let n_read = reader.read_to_end(&mut buf).unwrap();
         assert_eq!(n_read, TEST_STRING.len());


### PR DESCRIPTION
clippy says `n` and `i` are i32 and warns about the cast to usize

```rust
error: casting `i32` to `usize` may lose the sign of the value
  --> build.rs:32:32
   |
32 |         let mut crc = table[0][n as usize];
   |                                ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
```

This calms down clippy about those, and a few other minor issues it raises.