### PR TITLE
fix latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 //! Otherwise, the crate will use `cpuid` at runtime to detect the
 //! running CPU's features, and enable the appropriate algorithm.
 
-#![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
 
 mod combine;
 mod hasher;


### PR DESCRIPTION
```bash
error[E0635]: unknown feature `stdarch_arm_crc32`
  --> /Users/lz1998/.cargo/registry/src/rsproxy.cn-8f6827c7555bfaf8/crc32c-0.6.5/src/lib.rs:23:60
   |
23 | #![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
   |                                                            ^^^^^^^^^^^^^^^^^
```