### PR TITLE
chore: bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crc32c"
-version = "0.6.5"
+version = "0.7.0"
 authors = ["Zack Owens"]
 license = "Apache-2.0/MIT"
 keywords = ["crc", "simd"]


### PR DESCRIPTION
cc @zowens 

Move forward a bit to release https://github.com/zowens/crc32c/pull/60.

I suppose this is somehow a "breaking change" that satisfies a minor version bump in 0ver to notify users.