### PR TITLE
fix for nightly-2024-05-21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["Zack Owens"]
 license = "Apache-2.0/MIT"
 keywords = ["crc", "simd"]
@@ -10,14 +10,11 @@ homepage = "https://github.com/zowens/crc32c"
 documentation = "http://docs.rs/crc32c"
 edition = "2018"
 description = "Safe implementation for hardware accelerated CRC32C instructions with software fallback"
-exclude = [
-    "benches/*",
-    "tests/*",
-]
+exclude = ["benches/*", "tests/*"]
 build = "build.rs"
 
 [dev-dependencies]
-rand = { version ="0.8", features=["alloc", "getrandom"] }
+rand = { version = "0.8", features = ["alloc", "getrandom"] }
 criterion = "0.5"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,8 @@
 //! Otherwise, the crate will use `cpuid` at runtime to detect the
 //! running CPU's features, and enable the appropriate algorithm.
 
-<<<<<<< HEAD
-||||||| parent of 0f11222 (fix(arm): fix issue #62)
-#![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
-
-=======
 #![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_aarch64_crc32))]
 
->>>>>>> 0f11222 (fix(arm): fix issue #62)
 mod combine;
 mod hasher;
 #[cfg(all(target_arch = "aarch64", nightly))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,14 @@
 //! Otherwise, the crate will use `cpuid` at runtime to detect the
 //! running CPU's features, and enable the appropriate algorithm.
 
+<<<<<<< HEAD
+||||||| parent of 0f11222 (fix(arm): fix issue #62)
+#![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
+
+=======
+#![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_aarch64_crc32))]
+
+>>>>>>> 0f11222 (fix(arm): fix issue #62)
 mod combine;
 mod hasher;
 #[cfg(all(target_arch = "aarch64", nightly))]


### PR DESCRIPTION
- relates to nightly-2024-05-21
- relates somehow to
  - #62 
  - #63 
  - #60
  - #64 
- change to the feature toggle `feature(stdarch_aarch64_crc32)`
  - see https://github.com/rust-lang/stdarch/pull/1573
- this feature gate is removed on master, I believe for the version series `v0.6.x` we better just keep it, and for the next `v0.7.x` it can be removed as already on master
  - see also the comment here: https://github.com/zowens/crc32c/pull/64#issuecomment-2132187120

The error message before this fix looks like this:

```raw
error[E0635]: unknown feature `stdarch_arm_crc32`
  --> /Users/JohnDow/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.5/src/lib.rs:23:60
   |
23 | #![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
   |                                                            ^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `crc32c` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```