### PR TITLE
Release 0.6.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["Zack Owens"]
 license = "Apache-2.0/MIT"
 keywords = ["crc", "simd"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hardware acceleration on the following architectures:
     * All stable versions of Rust
     * If SSE 4.2 is enabled at compile time, it will only build the SSE implementation. Otherwise, the `cpuid` is used to find the best implementation at runtime.
 1. **aarch64** with [crc feature](https://developer.arm.com/documentation/dui0801/g/A32-and-T32-Instructions/CRC32C)
-    * Only available on nightly (enabled by default without feature)
+    * Only available on rust version >= 1.80.0 or nightly
 
 All other processors utilize a software fallback.
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::uninit_assumed_init)]
 extern crate rustc_version;
 
-use rustc_version::{version_meta, Channel};
+use rustc_version::{Version, version};
 use std::io::Write;
 use std::path::Path;
 use std::{io, ops};
@@ -183,9 +183,19 @@ fn write_tables() -> io::Result<()> {
 }
 
 fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
     write_tables().expect("Failed to write CRC tables");
+    let min_version = Version::new(1, 80, 0);
 
-    if version_meta().unwrap().channel == Channel::Nightly {
-        println!("cargo:rustc-cfg=nightly");
+    let current_version = {
+        // rmeove prerelease tag for now, if it exists
+        let vers = version().unwrap();
+        Version::new(vers.major, vers.minor, vers.patch)
+    };
+
+    // only stable in nightly versions for 1.80 and above
+    println!("cargo::rustc-check-cfg=cfg(armsimd)");
+    if current_version >= min_version {
+        println!("cargo::rustc-cfg=armsimd");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::uninit_assumed_init)]
 extern crate rustc_version;
 
-use rustc_version::{Version, version};
+use rustc_version::{version, Version};
 use std::io::Write;
 use std::path::Path;
 use std::{io, ops};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 
 mod combine;
 mod hasher;
-#[cfg(all(target_arch = "aarch64", nightly))]
+#[cfg(all(target_arch = "aarch64", armsimd))]
 mod hw_aarch64;
-#[cfg(any(target_arch = "x86_64", all(target_arch = "aarch64", nightly)))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod hw_tables;
 #[cfg(target_arch = "x86_64")]
 mod hw_x86_64;
@@ -54,7 +54,7 @@ pub fn crc32c_append(crc: u32, data: &[u8]) -> u32 {
         }
     }
 
-    #[cfg(all(target_arch = "aarch64", nightly))]
+    #[cfg(all(target_arch = "aarch64", armsimd))]
     {
         if std::arch::is_aarch64_feature_detected!("crc") {
             return unsafe { hw_aarch64::crc32c(crc, data) };


### PR DESCRIPTION
This updates the crate for stable AARCH64 SIMD features. I've added some code in build.rs to detect the right version to make the transition smooth for users that are on AARCH64 but _not_ on the stable version.